### PR TITLE
feat: cross-platform macOS + Linux bootstrap (+ tpm to tpack)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -150,7 +150,17 @@ export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin:$HOME/bin:$HOME/.pyenv/bin
 # export SSH_AGENT_PID
 # export SSH_AUTH_SOCK
 
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
-eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-eval "$(starship init zsh)"
+# brew shellenv — detect prefix per platform
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ -x /opt/homebrew/bin/brew ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -x /usr/local/bin/brew ]]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+elif [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+
+command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init -)"
+command -v pyenv >/dev/null 2>&1 && eval "$(pyenv virtualenv-init -)"
+command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"

--- a/Brewfile
+++ b/Brewfile
@@ -17,6 +17,10 @@ brew "go"
 brew "tree-sitter"
 brew "lsd"
 
+# tmux plugin manager (drop-in tpm replacement)
+tap "tmuxpack/tpack"
+cask "tpack"
+
 # GUI / apps
 cask "kitty"
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,25 @@
+# macOS one-shot install: brew bundle --file=Brewfile
+# Mirrors what the Linux apt targets install. Keep in sync with Makefile.
+
+# core CLI
+brew "git"
+brew "tmux"
+brew "stow"
+brew "ripgrep"
+brew "neovim"
+brew "starship"
+brew "lua"
+brew "luarocks"
+brew "pyenv"
+brew "pyenv-virtualenv"
+brew "nvm"
+brew "go"
+brew "tree-sitter"
+brew "lsd"
+
+# GUI / apps
+cask "kitty"
+
+# nerd font
+tap "homebrew/cask-fonts"
+cask "font-meslo-lg-nerd-font"

--- a/Brewfile
+++ b/Brewfile
@@ -16,6 +16,7 @@ brew "nvm"
 brew "go"
 brew "tree-sitter"
 brew "lsd"
+brew "gh"
 
 # tmux plugin manager (drop-in tpm replacement)
 tap "tmuxpack/tpack"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ bootstrap: bootstrap-$(OS) ## OS-aware full bootstrap
 # ────────────────────────────────────────────────────────────────────────────
 # macOS
 # ────────────────────────────────────────────────────────────────────────────
-bootstrap-macos: brew-install brewfile-install zsh-install zsh-install-plugins tmux-tpm-install nvim-subtree-init stow-macos ssh-enable-macos ## macOS full bootstrap
+bootstrap-macos: brew-install brewfile-install zsh-install zsh-install-plugins nvim-subtree-init stow-macos ssh-enable-macos ## macOS full bootstrap
 
 brew-install: ## install homebrew (macos + linux)
 	/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -39,7 +39,7 @@ stow-macos: ## stow macOS-relevant configs
 # ────────────────────────────────────────────────────────────────────────────
 # Linux (apt — Ubuntu/Debian)
 # ────────────────────────────────────────────────────────────────────────────
-bootstrap-linux: linux-homebrew-install zsh-install zsh-install-plugins tmux-install tmux-tpm-install stow-install ripgrep-install lua-install pyenv-install go-install fonts-install starship-install kitty-install nvim-install-nightly-ppa nvim-subtree-init stow-linux ssh-enable-service ## linux full bootstrap
+bootstrap-linux: linux-homebrew-install zsh-install zsh-install-plugins tmux-install tpack-install stow-install ripgrep-install lua-install pyenv-install go-install fonts-install starship-install kitty-install nvim-install-nightly-ppa nvim-subtree-init stow-linux ssh-enable-service ## linux full bootstrap
 
 linux-homebrew-install: ## install linux homebrew
 	/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -140,8 +140,11 @@ zsh-install: ## install oh-my-zsh
 zsh-install-plugins: ## install omzsh plugins
 	git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
 
-tmux-tpm-install: ## install tpm
-	git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+tpack-install: ## install tpack (tmux plugin manager, tpm replacement)
+	brew install tmuxpack/tpack/tpack
+
+tpack-plugins-install: ## install plugins declared in tmux.conf via tpack
+	tpack install
 
 nvim-subtree-init: ## init nvim lua via subtree
 	git subtree add --prefix nvim/.config/nvim git@github.com:nkane/init.lua.git main --squash

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,53 @@
+SHELL := /bin/bash
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+OS := macos
+else ifeq ($(UNAME_S),Linux)
+OS := linux
+else
+OS := unknown
+endif
+
 all: help
-.PHONY: help 
+.PHONY: help bootstrap bootstrap-macos bootstrap-linux stow stow-macos stow-linux
+
+bootstrap: bootstrap-$(OS) ## OS-aware full bootstrap
+
+# ────────────────────────────────────────────────────────────────────────────
+# macOS
+# ────────────────────────────────────────────────────────────────────────────
+bootstrap-macos: brew-install brewfile-install zsh-install zsh-install-plugins tmux-tpm-install nvim-subtree-init stow-macos ssh-enable-macos ## macOS full bootstrap
+
+brew-install: ## install homebrew (macos + linux)
+	/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+brewfile-install: ## install everything in Brewfile (macos)
+	brew bundle --file=Brewfile
+
+ssh-enable-macos: ## load ssh keys into macOS keychain
+	bash scripts/ssh-agent-macos.sh
+
+stow-macos: ## stow macOS-relevant configs
+	stow kitty
+	stow nvim
+	stow starship
+	stow tmux
+	stow ssh
+	stow claude
+
+# ────────────────────────────────────────────────────────────────────────────
+# Linux (apt — Ubuntu/Debian)
+# ────────────────────────────────────────────────────────────────────────────
+bootstrap-linux: linux-homebrew-install zsh-install zsh-install-plugins tmux-install tmux-tpm-install stow-install ripgrep-install lua-install pyenv-install go-install fonts-install starship-install kitty-install nvim-install-nightly-ppa nvim-subtree-init stow-linux ssh-enable-service ## linux full bootstrap
+
+linux-homebrew-install: ## install linux homebrew
+	/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 nvim-install-nightly-ppa: ## install nightly neovim ppa
 	sudo add-apt-repository ppa:neovim-ppa/unstable
 	sudo apt update -y
 	sudo apt install neovim -y
-	
-nvim-subtree-init: ## init nvim lua configuration via subtree
-	git subtree add --prefix nvim/.config/nvim git@github.com:nkane/init.lua.git main --squash
-
-nvim-subtree-pull: ## pull nvim lua configuration via subtree
-	git subtree pull --prefix nvim/.config/nvim git@github.com:nkane/init.lua.git main --squash
-
-nvim-subtree-push: ## push nvim lua configuration changes to subtree remote
-	git subtree push --prefix nvim/.config/nvim git@github.com:nkane/init.lua.git main
-
-tmux-tpm-install: ## install tpm by cloning github repo to ~/.tmux/plugins/tpm
-	git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
-
-caveman-install: ## install caveman Claude Code plugin from JuliusBrussee/caveman
-	claude plugin marketplace add JuliusBrussee/caveman
-	claude plugin install caveman@caveman
-
-linux-homebrew-install: ## install linux homebrew
-	/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 kitty-install: ## install kitty
 	curl -L https://sw.kovidgoyal.net/kitty/installer.sh | sh /dev/stdin
@@ -34,15 +58,6 @@ stow-install: ## install stow
 tmux-install: ## install tmux
 	sudo apt install tmux -y
 
-zsh-install: ## install omzsh
-	sh -c "$$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-
-zsh-install-plugins: ## install omzsh plugins
-	git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
-
-starship-install: ## install starship
-	curl -sS https://starship.rs/install.sh | sh
-
 ripgrep-install: ## install ripgrep
 	sudo apt install ripgrep -y
 
@@ -50,14 +65,14 @@ lua-install: ## install lua
 	sudo apt install lua5.4 liblua5.4-dev -y
 	sudo apt install luarocks -y
 
-pyenv-install: ## install pyenv
+pyenv-install: ## install pyenv (linux build deps)
 	sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
 		libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev \
 		libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
 	curl https://pyenv.run | bash
 	sudo apt install python3.12-venv -y
 
-go-install: ## install go
+go-install: ## install go (linux tarball)
 	@echo '[Downloading golang]'
 	wget https://dl.google.com/go/go1.22.5.linux-amd64.tar.gz
 	@if [ -d "/usr/local/go" ]; then sudo rm -rf /usr/local/go; fi
@@ -66,39 +81,39 @@ go-install: ## install go
 	/usr/local/go/bin/go version
 	@echo 'done!'
 
-fonts-install: ## install fonts
+fonts-install: ## install Meslo nerd font (linux)
 	echo "[-] Download fonts [-]"
 	wget https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/Meslo.zip
 	unzip Meslo.zip -d ~/.fonts
 	fc-cache -fv
 	echo "done!"
 
-i3-install: ## install i3
+i3-install: ## install i3 (linux only)
 	curl https://baltocdn.com/i3-window-manager/signing.asc | sudo apt-key add -
 	sudo apt install apt-transport-https --yes
 	echo "deb https://baltocdn.com/i3-window-manager/i3/i3-autobuild-ubuntu/ all main" | sudo tee /etc/apt/sources.list.d/i3-autobuild.list
 	sudo apt update
 	sudo apt install i3
 
-polybar-install: ## install polybar
+polybar-install: ## install polybar (linux only)
 	sudo apt install polybar -y
 
-picom-install: ## install picom
+picom-install: ## install picom (linux only)
 	sudo apt install picom -y
 
-rofi-install: ## install rofi
+rofi-install: ## install rofi (linux only)
 	sudo apt install rofi -y
 
-xrandr-install: 
+xrandr-install: ## install xrandr (linux only)
 	sudo apt install x11-xserver-utils -y
 
-ssh-enable-service:
+ssh-enable-service: ## enable systemd ssh-agent service (linux)
 	systemctl --user enable --now ssh-agent
 	chmod 600 ~/.ssh/config
-	chown ${USER} ~/.ssh/config
+	chown $${USER} ~/.ssh/config
 
-stow: ## stow nvim
-	stow kitty 
+stow-linux: ## stow Linux configs (includes X11 / systemd)
+	stow kitty
 	stow nvim
 	stow starship
 	stow tmux
@@ -111,5 +126,40 @@ stow: ## stow nvim
 	stow ssh
 	stow claude
 
+# ────────────────────────────────────────────────────────────────────────────
+# OS-agnostic
+# ────────────────────────────────────────────────────────────────────────────
+stow: stow-$(OS) ## OS-aware stow dispatcher
+
+starship-install: ## install starship
+	curl -sS https://starship.rs/install.sh | sh
+
+zsh-install: ## install oh-my-zsh
+	sh -c "$$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+zsh-install-plugins: ## install omzsh plugins
+	git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+
+tmux-tpm-install: ## install tpm
+	git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+
+nvim-subtree-init: ## init nvim lua via subtree
+	git subtree add --prefix nvim/.config/nvim git@github.com:nkane/init.lua.git main --squash
+
+nvim-subtree-pull: ## pull nvim lua via subtree
+	git subtree pull --prefix nvim/.config/nvim git@github.com:nkane/init.lua.git main --squash
+
+nvim-subtree-push: ## push nvim lua subtree
+	git subtree push --prefix nvim/.config/nvim git@github.com:nkane/init.lua.git main
+
+caveman-install: ## install caveman Claude Code plugin from JuliusBrussee/caveman
+	claude plugin marketplace add JuliusBrussee/caveman
+	claude plugin install caveman@caveman
+
+doctor: ## print detected OS / arch / pkg
+	@bash -c 'source scripts/detect-os.sh && echo "OS=$$OS ARCH=$$ARCH PKG=$$PKG BREW_PREFIX=$$BREW_PREFIX"'
+
 help: ## Display this help screen
+	@echo "Detected OS: $(OS)"
+	@echo ""
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -1,34 +1,52 @@
 ### nkane's dotfiles
 
-#### SSH User Systemd Service
+Cross-platform: macOS + Linux (Ubuntu/Debian).
 
-- Save the service file in the location '~/.config/systemd/user/ssh-agent.service'.
-- Reload the user daemon:
+`make doctor` prints the detected OS / arch / pkg manager.
+
+#### macOS install
+
+```bash
+git clone <this repo> ~/dotfiles && cd ~/dotfiles
+make bootstrap          # OS-aware; runs bootstrap-macos
+# or step-by-step:
+make brew-install
+make brewfile-install
+make zsh-install zsh-install-plugins
+make tmux-tpm-install
+make nvim-subtree-init
+make stow               # stows kitty/nvim/starship/tmux/ssh
+make ssh-enable-macos   # loads ~/.ssh/id_* into keychain
+```
+
+`Brewfile` is the source of truth for macOS packages — keep it in sync with the Linux apt targets in the `Makefile`.
+
+#### Linux (Ubuntu/Debian) install
+
+```bash
+git clone <this repo> ~/dotfiles && cd ~/dotfiles
+make bootstrap          # OS-aware; runs bootstrap-linux
+```
+
+Linux uses the apt-based targets in the `Makefile` plus the X11 stack (`i3`, `polybar`, `picom`, `rofi`) and a systemd ssh-agent service.
+
+##### SSH agent (Linux, systemd)
+
+Save the service file to `~/.config/systemd/user/ssh-agent.service` via `stow systemd`, then:
 
 ```bash
 systemctl --user daemon-reload
-```
-
-- Enable the service:
-
-```bash
 systemctl --user enable ssh-agent.service
-```
-
-- Start the service:
-
-```bash
 systemctl --user start ssh-agent.service
-```
-
-- Check the service status:
-
-```bash
 systemctl --user status ssh-agent.service
-```
-
-- View logs:
-
-```bash
 journalctl --user -u ssh-agent.service
 ```
+
+#### Layout
+
+| dir | purpose | platform |
+| --- | --- | --- |
+| `kitty/`, `nvim/`, `tmux/`, `starship/`, `ssh/`, `zsh/`, `bash/`, `git/`, `js/`, `lua/`, `claude/` | shared configs | both |
+| `i3/`, `polybar/`, `picom/`, `rofi/`, `systemd/`, `environment.d/` | X11 / systemd | linux |
+| `scripts/` | helpers (`detect-os.sh`, `ssh-agent-macos.sh`) | both |
+| `Brewfile` | macOS package list | macos |

--- a/scripts/detect-os.sh
+++ b/scripts/detect-os.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Detect OS / arch / package manager / brew prefix. Source me; do not exec.
+# Sets: OS, ARCH, PKG, BREW_PREFIX (when applicable).
+
+case "$(uname -s)" in
+    Darwin) OS=macos ;;
+    Linux)  OS=linux ;;
+    *)      OS=unknown ;;
+esac
+
+case "$(uname -m)" in
+    arm64|aarch64) ARCH=arm64 ;;
+    x86_64)        ARCH=x86_64 ;;
+    *)             ARCH=$(uname -m) ;;
+esac
+
+if [ "$OS" = "macos" ]; then
+    PKG=brew
+    if [ "$ARCH" = "arm64" ]; then
+        BREW_PREFIX=/opt/homebrew
+    else
+        BREW_PREFIX=/usr/local
+    fi
+elif [ "$OS" = "linux" ]; then
+    if command -v apt-get >/dev/null 2>&1; then
+        PKG=apt
+    elif command -v dnf >/dev/null 2>&1; then
+        PKG=dnf
+    elif command -v pacman >/dev/null 2>&1; then
+        PKG=pacman
+    else
+        PKG=unknown
+    fi
+    if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+        BREW_PREFIX=/home/linuxbrew/.linuxbrew
+    fi
+fi
+
+export OS ARCH PKG BREW_PREFIX

--- a/scripts/ssh-agent-macos.sh
+++ b/scripts/ssh-agent-macos.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Load all ~/.ssh/id_* private keys into the macOS keychain-backed ssh-agent.
+# macOS ssh-agent runs under launchd by default; no systemd unit needed.
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "this script is macOS only" >&2
+    exit 1
+fi
+
+chmod 600 ~/.ssh/config 2>/dev/null || true
+
+shopt -s nullglob
+for key in ~/.ssh/id_*; do
+    case "$key" in
+        *.pub) continue ;;
+    esac
+    chmod 600 "$key"
+    ssh-add --apple-use-keychain "$key" || true
+done
+
+echo "ssh keys loaded into keychain"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -79,7 +79,6 @@ set-option -g status-position top
 set -g @catppuccin_window_status_style "rounded"
 
 # List of plugins
-set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'catppuccin/tmux#v2.1.0'
 set -g @plugin 'tmux-plugins/tmux-battery'
@@ -102,4 +101,5 @@ set -g status-left ""
 set -g status-right "#{E:@catppuccin_status_application} #{E:@catppuccin_status_session}"
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
+#run '~/.tmux/plugins/tpm/tpm'
+run 'tpack init'


### PR DESCRIPTION
## Summary

Make the dotfiles repo bootstrap cleanly on both macOS and Ubuntu/Debian, and swap the tmux plugin manager from TPM to tpack.

## Changes

- **OS detection**: `scripts/detect-os.sh` exports `OS`, `ARCH`, `PKG`, `BREW_PREFIX`. `make doctor` prints the detected platform.
- **Makefile**: split into `bootstrap-macos` / `bootstrap-linux` paths behind a single `make bootstrap` dispatcher. `stow` is now an OS-aware dispatcher (`stow-macos` skips X11/systemd packages; both stow the new `claude` skills package).
- **Brewfile**: new — source of truth for macOS packages (`brew bundle --file=Brewfile`). Mirrors the Linux apt targets and pulls Meslo Nerd Font, tpack, and the `gh` CLI via casks/formulae.
- **`.zshrc` portability**: brew/pyenv/starship eval per detected platform; no more hardcoded `/home/linuxbrew/.linuxbrew/bin/brew` on macOS.
- **macOS ssh-agent**: `scripts/ssh-agent-macos.sh` loads `~/.ssh/id_*` into the keychain. Linux keeps its systemd unit.
- **tpm → tpack**: tmux.conf bottom line is now `run 'tpack init'`; obsolete `set -g @plugin 'tmux-plugins/tpm'` line removed. New `tpack-install` make target (Homebrew tap on both macOS and Linuxbrew).
- **README**: split into separate macOS and Linux install sections + layout table.

## Testing

- `make doctor` -> `OS=macos ARCH=arm64 PKG=brew BREW_PREFIX=/opt/homebrew`.
- `make help` enumerates targets cleanly with `Detected OS: macos` banner.
- `make -n bootstrap-macos` dry-run expands the full chain.
- `zsh -ic` on macOS resolves `brew`, `pyenv`, `starship` against `/opt/homebrew`.
- tpack already installed via brew cask (`tpack 1.1.0`); `tpack --help` confirms the binary is on PATH and tmux loads plugins via the new init line.
- macOS install audit: all bootstrap-relevant tools present (brew, git, nvim, tmux, stow, lua, luarocks, node/npm, go, pyenv, starship, ripgrep, kitty, omzsh+plugins, tpack, Xcode CLT). Only gaps were the Meslo Nerd Font and the `gh` CLI, both now covered by the Brewfile.
- Linux path not exercised on this push (no Linux host handy) — apt targets are unchanged in substance, only reorganized into `bootstrap-linux`.

## Notes

- No ADR directory exists in this repo. If we want to start one for decisions like this, happy to scaffold `docs/adr/` in a follow-up PR rather than invent a scheme silently here.
- Pre-existing dirty file `nvim/.config/nvim/lazy-lock.json` was deliberately left out of the PR.
- After merge, run `make stow` (or just `stow claude`) on macOS to symlink the new `claude/.claude/skills/` package into `~/.claude/skills/`.